### PR TITLE
override build mode of SDL2 dependency to ReleaseFast

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -75,6 +75,7 @@ fn make_binary_variant(
             @import("deps/zig-sdl/build.zig").linkArtifact(b, .{
                 .artifact = exe,
                 .prefix = "deps/zig-sdl",
+                .override_mode = .ReleaseFast,
             });
         } else {
             exe.linkSystemLibrary("SDL2");


### PR DESCRIPTION
with ziglang/zig#3570 merged into zig, SDL2
built in debug mode trips undefined behavior sanitization. Since this
project is not SDL2 itself and is rather using SDL2 as a dependency,
we avoid this by overriding the build mode of the SDL2 dependency to
be always ReleaseFast.

This has the additional benefit of making debug builds of
legend-of-swarkland more viable, since "hot paths" which include
SDL2 function calls are now using optimized SDL2 builds.

This pull request depends on #61