### PR TITLE
Update to Zig 0.8.0

### DIFF
--- a/src/client/game_engine_client.zig
+++ b/src/client/game_engine_client.zig
@@ -200,7 +200,7 @@ pub const GameEngineClient = struct {
                         defer core.debug.thread_lifecycle.print("shutdown", .{});
 
                         game_server.server_main(context) catch |err| {
-                            std.debug.warn("error: {}", .{@errorName(err)});
+                            std.debug.warn("error: {s}", .{@errorName(err)});
                             if (@errorReturnTrace()) |trace| {
                                 std.debug.dumpStackTrace(trace.*);
                             }
@@ -209,7 +209,7 @@ pub const GameEngineClient = struct {
                     }
                 };
                 break :blk Connection.ThreadData{
-                    .core_thread = try std.Thread.spawn(&self.queues, LambdaPlease.f),
+                    .core_thread = try std.Thread.spawn(LambdaPlease.f, &self.queues),
                 };
             },
         };

--- a/src/core/protocol.zig
+++ b/src/core/protocol.zig
@@ -251,7 +251,7 @@ pub fn InChannel(comptime Reader: type) type {
             switch (@typeInfo(T)) {
                 .Int => return self.readInt(T),
                 .Bool => return 0 != try self.readInt(u1),
-                .Enum => return @intToEnum(T, try self.readInt(@TagType(T))),
+                .Enum => return @intToEnum(T, try self.readInt(std.meta.Tag(T))),
                 .Struct => |info| {
                     var x: T = undefined;
                     inline for (info.fields) |field| {

--- a/src/gui/gui_main.zig
+++ b/src/gui/gui_main.zig
@@ -45,7 +45,7 @@ pub fn main() anyerror!void {
         std.debug.panic("failed to disable sdl signal handlers\n", .{});
     }
     if (sdl.c.SDL_Init(sdl.c.SDL_INIT_VIDEO) != 0) {
-        std.debug.panic("SDL_Init failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_Init failed: {s}\n", .{sdl.c.SDL_GetError()});
     }
     defer sdl.c.SDL_Quit();
 
@@ -57,12 +57,12 @@ pub fn main() anyerror!void {
         logical_window_size.h,
         sdl.c.SDL_WINDOW_RESIZABLE,
     ) orelse {
-        std.debug.panic("SDL_CreateWindow failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_CreateWindow failed: {s}\n", .{sdl.c.SDL_GetError()});
     };
     defer sdl.c.SDL_DestroyWindow(screen);
 
     const renderer: *sdl.Renderer = sdl.c.SDL_CreateRenderer(screen, -1, 0) orelse {
-        std.debug.panic("SDL_CreateRenderer failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_CreateRenderer failed: {s}\n", .{sdl.c.SDL_GetError()});
     };
     defer sdl.c.SDL_DestroyRenderer(renderer);
 
@@ -81,7 +81,7 @@ pub fn main() anyerror!void {
         logical_window_size.w,
         logical_window_size.h,
     ) orelse {
-        std.debug.panic("SDL_CreateTexture failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_CreateTexture failed: {s}\n", .{sdl.c.SDL_GetError()});
     };
     defer sdl.c.SDL_DestroyTexture(screen_buffer);
 
@@ -461,7 +461,7 @@ fn doMainLoop(renderer: *sdl.Renderer, screen_buffer: *sdl.Texture) !void {
                     if (score == 1) {
                         maybe_tutorial_text = "you are win. use Ctrl+R to quit.";
                     } else {
-                        dealloc_buffer = try std.fmt.allocPrint(allocator, "team {} wins with {} points. Ctrl+R to quit.", .{
+                        dealloc_buffer = try std.fmt.allocPrint(allocator, "team {s} wins with {} points. Ctrl+R to quit.", .{
                             @tagName(frame.self.species),
                             score,
                         });

--- a/src/gui/sdl.zig
+++ b/src/gui/sdl.zig
@@ -45,7 +45,7 @@ pub fn makeRect(rect: geometry.Rect) sdl.c.SDL_Rect {
 
 pub fn assertZero(ret: c_int) void {
     if (ret == 0) return;
-    std.debug.panic("sdl function returned an error: {c}", .{sdl.c.SDL_GetError()});
+    std.debug.panic("sdl function returned an error: {s}", .{sdl.c.SDL_GetError()});
 }
 
 pub const Renderer = sdl.c.SDL_Renderer;

--- a/src/gui/textures.zig
+++ b/src/gui/textures.zig
@@ -28,16 +28,16 @@ pub fn deinit() void {
 
 fn loadTexture(renderer: *sdl.Renderer, buffer: []const u8, width: i32, height: i32) *sdl.c.SDL_Texture {
     var texture: *sdl.c.SDL_Texture = sdl.c.SDL_CreateTexture(renderer, sdl.c.SDL_PIXELFORMAT_RGBA8888, sdl.c.SDL_TEXTUREACCESS_STATIC, width, height) orelse {
-        std.debug.panic("SDL_CreateTexture failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_CreateTexture failed: {s}\n", .{sdl.c.SDL_GetError()});
     };
 
     if (sdl.c.SDL_SetTextureBlendMode(texture, @intToEnum(sdl.c.SDL_BlendMode, sdl.c.SDL_BLENDMODE_BLEND)) != 0) {
-        std.debug.panic("SDL_SetTextureBlendMode failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_SetTextureBlendMode failed: {s}\n", .{sdl.c.SDL_GetError()});
     }
 
     const pitch = width * 4;
     if (sdl.c.SDL_UpdateTexture(texture, 0, @ptrCast(?*const c_void, buffer.ptr), pitch) != 0) {
-        std.debug.panic("SDL_UpdateTexture failed: {c}\n", .{sdl.c.SDL_GetError()});
+        std.debug.panic("SDL_UpdateTexture failed: {s}\n", .{sdl.c.SDL_GetError()});
     }
 
     return texture;

--- a/src/server/server_main.zig
+++ b/src/server/server_main.zig
@@ -22,8 +22,8 @@ const FdToQueueAdapter = struct {
     ) !void {
         self.socket = Socket.init(in_stream, out_stream);
         self.queues = queues;
-        self.send_thread = try std.Thread.spawn(self, sendMain);
-        self.recv_thread = try std.Thread.spawn(self, recvMain);
+        self.send_thread = try std.Thread.spawn(sendMain, self);
+        self.recv_thread = try std.Thread.spawn(recvMain, self);
     }
 
     pub fn wait(self: *FdToQueueAdapter) void {


### PR DESCRIPTION
### Summary
Noticed the build was failing, mostly due to the different print syntax, Thread usage, and deprecated builtins.

### Changes
- [x] Use `{s}` instead of `{c}` or `{}`
- [x] Update Thread.spawn function argument ordering
- [x] Use `std.meta.Tag` as `@TagType` is deprecated

### Note
I'm not actually sure what version of Zig this is, but it's the latest.