### PR TITLE
Level select menu unlocks levels as you beat them

### DIFF
--- a/src/client/cheatcodes.zig
+++ b/src/client/cheatcodes.zig
@@ -121,7 +121,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Single kagaroo
+    // Kagaroo
     &[_]Action{
         Action{ .move = makeCoord(0, -1) },
         Action{ .move = makeCoord(1, 0) },
@@ -202,7 +202,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Charging enemy and lava
+    // Rhino and lava
     &[_]Action{
         Action{ .wait = {} },
         Action{ .wait = {} },
@@ -224,7 +224,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Charging enemy and an archer
+    // Rhino and archer
     &[_]Action{
         Action{ .move = makeCoord(1, 0) },
         Action{ .move = makeCoord(0, -1) },
@@ -252,7 +252,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Invicible enmies and a charging enemy
+    // Invicible enmies and a rhino
     &[_]Action{
         Action{ .kick = makeCoord(1, 0) },
         Action{ .move = makeCoord(0, 1) },
@@ -283,7 +283,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Archer guarding chokepoint
+    // Archer guarding a chokepoint
     &[_]Action{
         Action{ .move = makeCoord(-1, 0) },
         Action{ .move = makeCoord(0, -1) },
@@ -322,7 +322,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Some blob
+    // Some blobs
     &[_]Action{
         Action{ .move = makeCoord(1, 0) },
         Action{ .move = makeCoord(1, 0) },
@@ -449,7 +449,7 @@ pub const beat_level_actions = [_][]const Action{
         Action{ .move = makeCoord(1, 0) },
     },
 
-    // Kangaroos can't kick
+    // Kangaroos can't attack
     &[_]Action{
         Action{ .move = makeCoord(0, 1) },
         Action{ .move = makeCoord(0, 1) },

--- a/src/core/protocol.zig
+++ b/src/core/protocol.zig
@@ -89,7 +89,7 @@ pub const PerceivedFrame = struct {
 
     self: PerceivedThing,
     others: []PerceivedThing,
-    winning_score: ?i32,
+    completed_levels: u32,
     movement: Coord,
 };
 

--- a/src/gui/SaveFile.zig
+++ b/src/gui/SaveFile.zig
@@ -1,0 +1,21 @@
+completed_levels: u32 = 0,
+
+const std = @import("std");
+
+const filename = "save_5_6.swarkland";
+
+/// Fails silently and falls back to an empty save file.
+pub fn load() @This() {
+    var file = std.fs.cwd().openFile("save_5_6.swarkland", .{}) catch return @This(){};
+    defer file.close();
+    return @This(){
+        .completed_levels = file.reader().readIntLittle(u32) catch return @This(){},
+    };
+}
+
+/// Fails silently.
+pub fn save(save_file: @This()) void {
+    var file = std.fs.cwd().createFile("save_5_6.swarkland", .{}) catch return;
+    defer file.close();
+    file.writer().writeIntLittle(u32, save_file.completed_levels) catch return;
+}

--- a/src/gui/gui.zig
+++ b/src/gui/gui.zig
@@ -7,24 +7,22 @@ const makeCoord = geometry.makeCoord;
 const textures = @import("./textures.zig");
 
 pub const LinearMenuState = struct {
-    cursor_position: usize,
-    entry_count: usize,
-    enter_pressed: bool,
-    pub fn init() LinearMenuState {
-        return LinearMenuState{
-            .cursor_position = 0,
-            .entry_count = 0,
-            .enter_pressed = false,
-        };
+    cursor_position: usize = 0,
+    entry_count: usize = 0,
+    enter_pressed: bool = false,
+
+    pub fn moveUp(self: *LinearMenuState, how_many: usize) void {
+        if (self.cursor_position < how_many) {
+            self.cursor_position = 0;
+        } else {
+            self.cursor_position -= how_many;
+        }
     }
-    pub fn moveUp(self: *LinearMenuState) void {
-        if (self.cursor_position == 0) return;
-        self.cursor_position -= 1;
-    }
-    pub fn moveDown(self: *LinearMenuState) void {
-        self.cursor_position += 1;
-        if (self.cursor_position >= self.entry_count) {
-            self.cursor_position = if (self.entry_count == 0) 0 else self.entry_count - 1;
+    pub fn moveDown(self: *LinearMenuState, how_many: usize) void {
+        if (self.cursor_position + how_many >= self.entry_count) {
+            self.cursor_position = self.entry_count -| 1;
+        } else {
+            self.cursor_position += how_many;
         }
     }
     pub fn ensureButtonCount(self: *LinearMenuState, button_count: usize) void {
@@ -57,7 +55,7 @@ pub const Gui = struct {
             ._cursor_icon = cursor_icon,
             ._button_count = 0,
             ._cursor = geometry.makeCoord(0, 0),
-            ._scale = 0,
+            ._scale = 1,
             ._bold = false,
             ._marginBottom = 0,
         };

--- a/src/gui/gui_main.zig
+++ b/src/gui/gui_main.zig
@@ -543,7 +543,9 @@ fn doMainLoop(renderer: *sdl.Renderer, screen_buffer: *sdl.Texture) !void {
 
                 // tutorials
                 var maybe_tutorial_text: ?[]const u8 = null;
-                if (frame.self.activity == .death) {
+                if (state.animations != null and state.animations.?.turns > 10) {
+                    maybe_tutorial_text = "use Escape to skip animations.";
+                } else if (frame.self.activity == .death) {
                     maybe_tutorial_text = "you died. use Backspace to undo.";
                 } else if (frame.completed_levels == the_levels.len - 1) {
                     maybe_tutorial_text = "you are win. use Ctrl+R to quit.";

--- a/src/gui/input_engine.zig
+++ b/src/gui/input_engine.zig
@@ -21,6 +21,10 @@ pub const Button = enum {
     beat_level_5,
     unbeat_level,
     unbeat_level_5,
+    page_up,
+    page_down,
+    home,
+    end,
 };
 
 pub const InputEngine = struct {
@@ -45,8 +49,18 @@ pub const InputEngine = struct {
         switch (scancode) {
             sdl.c.SDL_SCANCODE_LEFT => return if (modifiers == 0) .left else null,
             sdl.c.SDL_SCANCODE_RIGHT => return if (modifiers == 0) .right else null,
-            sdl.c.SDL_SCANCODE_UP => return if (modifiers == 0) .up else null,
-            sdl.c.SDL_SCANCODE_DOWN => return if (modifiers == 0) .down else null,
+            sdl.c.SDL_SCANCODE_UP => if (modifiers == 0)
+                return .up
+            else if (modifiers == ctrl)
+                return .page_up
+            else
+                return null,
+            sdl.c.SDL_SCANCODE_DOWN => if (modifiers == 0)
+                return .down
+            else if (modifiers == ctrl)
+                return .page_down
+            else
+                return null,
             sdl.c.SDL_SCANCODE_F => return if (modifiers == 0) .start_attack else null,
             sdl.c.SDL_SCANCODE_K => return if (modifiers == 0) .start_kick else null,
             sdl.c.SDL_SCANCODE_R => return if (modifiers == ctrl) .restart else null,
@@ -66,6 +80,10 @@ pub const InputEngine = struct {
                 return .beat_level_5
             else
                 return null,
+            sdl.c.SDL_SCANCODE_PAGEUP => return if (modifiers == 0) .page_up else null,
+            sdl.c.SDL_SCANCODE_PAGEDOWN => return if (modifiers == 0) .page_down else null,
+            sdl.c.SDL_SCANCODE_HOME => return if (modifiers == 0) .home else null,
+            sdl.c.SDL_SCANCODE_END => return if (modifiers == 0) .end else null,
             else => return null,
         }
     }

--- a/src/server/game_engine.zig
+++ b/src/server/game_engine.zig
@@ -1187,20 +1187,6 @@ pub const GameEngine = struct {
             }
         }
 
-        var winning_score: ?i32 = 0;
-        const my_species = @as(std.meta.Tag(Species), game_state.individuals.get(my_id).?.species);
-        for (game_state.individuals.values()) |individual| {
-            if (my_species != individual.species) {
-                winning_score = null;
-                break;
-            }
-            winning_score.? += 1;
-        }
-        if (game_state.level_number < the_levels.len - 1) {
-            // jk, the game's not done yet.
-            winning_score = null;
-        }
-
         var your_new_head_coord = your_coord;
         switch (yourself.?.activity) {
             .movement, .growth => |move_delta| {
@@ -1221,7 +1207,7 @@ pub const GameEngine = struct {
             .self = yourself.?,
             .others = others.toOwnedSlice(),
             .terrain = terrain_chunk,
-            .winning_score = winning_score,
+            .completed_levels = game_state.level_number,
             .movement = your_new_head_coord.minus(your_coord), // sometimes the game server overrides this.
         };
     }

--- a/src/server/game_model.zig
+++ b/src/server/game_model.zig
@@ -92,7 +92,7 @@ pub const GameState = struct {
     allocator: Allocator,
     terrain: Terrain,
     individuals: IdMap(*Individual),
-    level_number: usize,
+    level_number: u32,
 
     pub fn generate(allocator: Allocator) !GameState {
         var game_state = GameState{

--- a/src/server/map_gen.zig
+++ b/src/server/map_gen.zig
@@ -45,8 +45,7 @@ pub fn generate(allocator: Allocator, terrain: *Terrain, individuals: *IdMap(*In
 pub const the_levels = blk: {
     @setEvalBranchQuota(10000);
     break :blk [_]Level{
-        // Single enemy
-        compileLevel(.{},
+        compileLevel("Single enemy", .{},
             \\#########
             \\        #
             \\ o      #
@@ -58,8 +57,7 @@ pub const the_levels = blk: {
             \\        #
             \\#########
         ),
-        // Multiple enemies
-        compileLevel(.{},
+        compileLevel("Multiple enemies", .{},
             \\#########
             \\        #
             \\        #
@@ -71,8 +69,7 @@ pub const the_levels = blk: {
             \\        #
             \\#########
         ),
-        // Archer in narrow hallway
-        compileLevel(.{},
+        compileLevel("Archer in narrow hallway", .{},
             \\#######
             \\;;;;;;#
             \\     o+
@@ -81,8 +78,7 @@ pub const the_levels = blk: {
             \\;;;;;;#
             \\#######
         ),
-        // Flanked by archers
-        compileLevel(.{},
+        compileLevel("Flanked by archers", .{},
             \\##########
             \\C        #
             \\   _     +
@@ -92,8 +88,7 @@ pub const the_levels = blk: {
             \\        C#
             \\##########
         ),
-        // Wall of archers
-        compileLevel(.{},
+        compileLevel("Wall of archers", .{},
             \\#############
             \\;;;;;;;;;;;;#
             \\     _      #
@@ -105,8 +100,8 @@ pub const the_levels = blk: {
             \\;;;;;;;;;;;;#
             \\#############
         ),
-        // Single kagaroo
-        compileLevel(.{},
+
+        compileLevel("Kangaroo", .{},
             \\#########
             \\        #
             \\        #
@@ -118,8 +113,7 @@ pub const the_levels = blk: {
             \\        #
             \\#########
         ),
-        // Invincible enemies
-        compileLevel(.{},
+        compileLevel("Invincible enemies", .{},
             \\#########
             \\        #
             \\        #
@@ -131,8 +125,7 @@ pub const the_levels = blk: {
             \\        #
             \\#########
         ),
-        // Invincible enemies and an archer
-        compileLevel(.{},
+        compileLevel("Invincible enemies and an archer", .{},
             \\#########
             \\        #
             \\        #
@@ -144,8 +137,8 @@ pub const the_levels = blk: {
             \\        #
             \\#########
         ),
-        // Charging enemy and lava
-        compileLevel(.{},
+
+        compileLevel("Rhino", .{},
             \\#######
             \\;;;;;;#
             \\      #
@@ -157,8 +150,7 @@ pub const the_levels = blk: {
             \\;;;;;;#
             \\#######
         ),
-        // Charging enemy and an archer
-        compileLevel(.{},
+        compileLevel("Rhino and archer", .{},
             \\#########
             \\        #
             \\  >     #
@@ -170,8 +162,7 @@ pub const the_levels = blk: {
             \\        #
             \\#########
         ),
-        // Invicible enmies and a charging enemy
-        compileLevel(.{},
+        compileLevel("Invicible enmies and a rhino", .{},
             \\#########
             \\        #
             \\        #
@@ -183,8 +174,7 @@ pub const the_levels = blk: {
             \\C       #
             \\#########
         ),
-        // Archer guarding chokepoint
-        compileLevel(.{},
+        compileLevel("Archer guarding a chokepoint", .{},
             \\#########
             \\     ;  #
             \\     ;  +
@@ -198,16 +188,14 @@ pub const the_levels = blk: {
             \\#########
         ),
 
-        // Some blobs
-        compileLevel(.{},
+        compileLevel("Some blobs", .{},
             \\######
             \\  ;  #
             \\_  b +
             \\  ; b#
             \\######
         ),
-        // Blob and other enemies
-        compileLevel(.{},
+        compileLevel("Blob and other enemies", .{},
             \\#######
             \\  + o;#
             \\_ + o +
@@ -216,8 +204,7 @@ pub const the_levels = blk: {
             \\      #
             \\#######
         ),
-        // Blob and incinvible enemies
-        compileLevel(.{},
+        compileLevel("Blob and incinvible enemies", .{},
             \\#######
             \\  + t;#
             \\_ + t +
@@ -227,8 +214,7 @@ pub const the_levels = blk: {
             \\#######
         ),
 
-        // You're the archer now!
-        compileLevel(.{ .polymorph_target = .centaur },
+        compileLevel("You're the archer now!", .{ .polymorph_target = .centaur },
             \\###########
             \\##        #
             \\=+ _      #
@@ -236,8 +222,7 @@ pub const the_levels = blk: {
             \\##        +
             \\###########
         ),
-        // Whose side are you on?
-        compileLevel(.{},
+        compileLevel("Whose side are you on?", .{},
             \\########
             \\  CCC  #
             \\      h+
@@ -249,8 +234,7 @@ pub const the_levels = blk: {
             \\########
         ),
 
-        // Kangaroos can't attack
-        compileLevel(.{ .polymorph_target = .kangaroo },
+        compileLevel("Kangaroos can't attack", .{ .polymorph_target = .kangaroo },
             \\########
             \\##  oo #
             \\=+ _ o +
@@ -260,20 +244,18 @@ pub const the_levels = blk: {
             \\########
         ),
 
-        // Blobs can't see
-        compileLevel(.{ .polymorph_target = .blob },
+        compileLevel("Blobs can't see", .{ .polymorph_target = .blob },
             \\##########
             \\   +o   ;#
             \\_;=+o #  +
             \\;; +; + ;#
             \\   +o +  #
             \\ +;+  +; #
-            \\     ++o #
+            \\     +#o #
             \\##########
         ),
 
-        // -_-
-        compileLevel(.{},
+        compileLevel("-_-", .{},
             \\##############
             \\             #
             \\ _ _  _  _ _ #
@@ -310,8 +292,9 @@ const Level = struct {
     height: u16,
     terrain: Terrain,
     individuals: []const Individual,
+    name: []const u8,
 };
-fn compileLevel(comptime options: Options, comptime source: []const u8) Level {
+fn compileLevel(name: []const u8, comptime options: Options, comptime source: []const u8) Level {
     // measure dimensions.
     const width = @intCast(u16, std.mem.indexOfScalar(u8, source, '\n').?);
     const height = @intCast(u16, @divExact(source.len + 1, width + 1));
@@ -321,6 +304,7 @@ fn compileLevel(comptime options: Options, comptime source: []const u8) Level {
         .height = height,
         .terrain = Terrain.initData(width, height, &terrain_space),
         .individuals = &[_]Individual{},
+        .name = name,
     };
 
     comptime var cursor: usize = 0;


### PR DESCRIPTION
Each time you beat a level, a save file is created/updated with a count of how many levels you've completed. This is loaded on startup, if found.

The main menu now has a submenu that lets you start on any previous level or the current level. It tells you the name of the previous levels, but not the name of the current level, because sometimes the name gives away the solution.
